### PR TITLE
Keep track of menu visits and redraw on return. Fixes #1

### DIFF
--- a/massif.lua
+++ b/massif.lua
@@ -19,7 +19,6 @@ local alt = false
 local midi_tune = false
 
 local dirty = true
-local dirty_from_menu = false
 
 local scale_options = {}
 
@@ -140,7 +139,7 @@ function init()
   local screen_metro = metro.init()
   screen_metro.time = 1/30
   screen_metro.event = function()
-    if not dirty_from_menu and _menu.mode then dirty = true end
+    if _menu.mode then dirty = true end
     redraw()
   end
   screen_metro:start()

--- a/massif.lua
+++ b/massif.lua
@@ -19,6 +19,7 @@ local alt = false
 local midi_tune = false
 
 local dirty = true
+local dirty_from_menu = false
 
 local scale_options = {}
 
@@ -138,7 +139,10 @@ function init()
   
   local screen_metro = metro.init()
   screen_metro.time = 1/30
-  screen_metro.event = function() redraw() end
+  screen_metro.event = function()
+    if not dirty_from_menu and _menu.mode then dirty = true end
+    redraw()
+  end
   screen_metro:start()
   
   pitch_tracker = poll.set("pitch_in_l")


### PR DESCRIPTION
Does this fix it... and in some reasonably acceptable programming style lol?

This suggested fix works by (somewhat brutally) repurposing `screen_metro` ~~to set variable `dirty_from_menu` and use it~~ to set `dirty` on menu visit.